### PR TITLE
Projection and New Discharge Name

### DIFF
--- a/R/geospatial.R
+++ b/R/geospatial.R
@@ -107,7 +107,7 @@ ExportGeogrid <- function(inFile, inVar, outFile, inCoordFile=NA,
   coords <- as.matrix(cbind(x, y))
   # Get geogrid and projection info
   map_proj <- ncdf4::ncatt_get(coordNC, varid=0, attname="MAP_PROJ")$value
-  cen_lat <- ncdf4::ncatt_get(coordNC, varid=0, attname="CEN_LAT")$value
+  cen_lat <- ncdf4::ncatt_get(coordNC, varid=0, attname="MOAD_CEN_LAT")$value
   cen_lon <- ncdf4::ncatt_get(coordNC, varid=0, attname="STAND_LON")$value
   truelat1 <- ncdf4::ncatt_get(coordNC, varid=0, attname="TRUELAT1")$value
   truelat2 <- ncdf4::ncatt_get(coordNC, varid=0, attname="TRUELAT2")$value

--- a/R/usgs_ingest.R
+++ b/R/usgs_ingest.R
@@ -765,8 +765,8 @@ LoadMetaDB <- function(path='.',
 #' @concept dataMgmt usgsStreamObs
 TransUsgsProdStat <- function(names, whichIn=FALSE) {
   ## Elsewhere these rely on a single set of parentheses around the units.
-  prodStatLookup <- c( X_00060_00011    ='Discharge (cfs)',   ##instantaneous is 00011 but not worth saying IMO
-                       X_00060_00011_cd ='Discharge code',
+  prodStatLookup <- c( X_00060_00000    ='Discharge (cfs)',   ##instantaneous is 00011 but not worth saying IMO
+                       X_00060_00000_cd ='Discharge code',
                        X_00065_00011    ='Stage (ft)',
                        X_00065_00011_cd ='Stage code' )
   code2Name <- any(names %in% names(prodStatLookup))

--- a/R/usgs_ingest.R
+++ b/R/usgs_ingest.R
@@ -766,7 +766,7 @@ LoadMetaDB <- function(path='.',
 TransUsgsProdStat <- function(names, whichIn=FALSE) {
   ## Elsewhere these rely on a single set of parentheses around the units.
   prodStatLookup <- c( X_00060_00000    ='Discharge (cfs)',   ##instantaneous is 00011 but not worth saying IMO
-                       X_00060_00000_cd ='Discharge code',
+                       X_00060_00000_cd ='Discharge code',    ## https://owi.usgs.gov/R/dataRetrieval.html#11
                        X_00065_00011    ='Stage (ft)',
                        X_00065_00011_cd ='Stage code' )
   code2Name <- any(names %in% names(prodStatLookup))


### PR DESCRIPTION
* `GetProj` function in `geospatial.R`  
```r
  map_proj <- ncdf4::ncatt_get(coordNC, varid=0, attname="MAP_PROJ")$value
  cen_lat <- ncdf4::ncatt_get(coordNC, varid=0, attname="MOAD_CEN_LAT")$value
  cen_lon <- ncdf4::ncatt_get(coordNC, varid=0, attname="STAND_LON")$value
  truelat1 <- ncdf4::ncatt_get(coordNC, varid=0, attname="TRUELAT1")$value
  truelat2 <- ncdf4::ncatt_get(coordNC, varid=0, attname="TRUELAT2")$value
```
`CEN_LAT` and `CEN_LON` are specific to the nested domain. If available, `MOAD_CEN_LAT` and `STAND_LON` are should be used.  

* `TransUsgsProdStat` function in `usgs_ingest.R`
```r
prodStatLookup <- c( X_00060_00011 ='Discharge (cfs)', ##instantaneous is 00011 but not worth saying IMO
X_00060_00011_cd ='Discharge code',
X_00065_00011 ='Stage (ft)',
X_00065_00011_cd ='Stage code' )
code2Name <- any(names %in% names(prodStatLookup))
```
 'Discharge (cfs)' in new USGS data  is denoted by `X_00060_00000` instead of `X_00060_00011`.
